### PR TITLE
Payments Bounded Context

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -6,6 +6,9 @@
         <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
         <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />
         <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
+        <MarkdownNavigatorCodeStyleSettings>
+          <option name="RIGHT_MARGIN" value="72" />
+        </MarkdownNavigatorCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -1,0 +1,17 @@
+dependencies {
+    compile project(':common')
+    compile project(':registration-contracts')
+    compile project(':conference-contracts')
+    compile project(':payment-contracts')
+}
+
+buildscript {
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+    dependencies {
+        classpath group: 'org.spine3.tools', name: 'protobuf-plugin', version: "$SPINE_PROTO_PLUGIN_VERSION", changing: true
+    }
+}
+
+apply plugin: 'org.spine3.tools.protobuf-plugin';

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/PaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/PaymentAggregate.java
@@ -30,9 +30,6 @@ import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.command.Assign;
 import org.spine3.server.entity.Entity;
 
-import java.util.Collections;
-import java.util.List;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static org.spine3.samples.lobby.payment.ThirdPartyProcessorPayment.PaymentStatus;
@@ -78,13 +75,13 @@ public class PaymentAggregate
 
         // Construct and return events
         final PaymentInstantiated resultEvent = PaymentInstantiated.newBuilder()
-                                                       .setId(getId())
-                                                       .build();
+                                                                   .setId(getId())
+                                                                   .build();
         return resultEvent;
     }
 
     @Assign
-    public List<Message> handle(CompleteThirdPartyProcessorPayment command, CommandContext context) throws FailureThrowable {
+    public Message handle(CompleteThirdPartyProcessorPayment command, CommandContext context) throws FailureThrowable {
         final boolean successful = command.getSuccessful();
         final PaymentStatus status = successful ? SUCCEED : FAILED;
         checkResultStatus(status);
@@ -101,7 +98,7 @@ public class PaymentAggregate
                                     : PaymentRejected.newBuilder()
                                                      .setId(id)
                                                      .build();
-        return Collections.singletonList(resultEvent);
+        return resultEvent;
     }
 
     @Assign
@@ -113,10 +110,10 @@ public class PaymentAggregate
                                                              .setStatus(status)
                                                              .build();
         incrementState(payment);
-        final PaymentId id = payment.getId();
+        final PaymentId id = getId();
         final PaymentCanceled resultEvent = PaymentCanceled.newBuilder()
-                                                   .setId(id)
-                                                   .build();
+                                                           .setId(id)
+                                                           .build();
         return resultEvent;
     }
 

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/PaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/PaymentAggregate.java
@@ -70,6 +70,7 @@ public class PaymentAggregate
         final OrderTotal total = command.getTotal();
         final Money orderCost = total.getTotalPrice();
         final ThirdPartyProcessorPayment.Builder newState = getState().toBuilder()
+                                                                      .setId(getId())
                                                                       .setPrice(orderCost);
         markInitialized(newState);
 
@@ -90,7 +91,7 @@ public class PaymentAggregate
                                                              .setStatus(status)
                                                              .build();
         incrementState(payment);
-        final PaymentId id = payment.getId();
+        final PaymentId id = getId();
         final Message resultEvent = successful
                                     ? PaymentCompleted.newBuilder()
                                                       .setId(id)

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/PaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/PaymentAggregate.java
@@ -44,7 +44,8 @@ import static org.spine3.samples.lobby.payment.ThirdPartyProcessorPayment.Paymen
  * @author Dmytro Dashenkov
  * @see org.spine3.samples.lobby.payment.procman.PaymentProcessManager
  */
-public class ThirdPartyPaymentAggregate
+// TODO:04-11-16:dmytro.dashenkov: Handle wrong addressd case (i.e. ID in command/event does not match aggregate ID).
+public class PaymentAggregate
         extends AbstractLobbyAggregate<PaymentId, ThirdPartyProcessorPayment, ThirdPartyProcessorPayment.Builder> {
 
     /**
@@ -57,7 +58,7 @@ public class ThirdPartyPaymentAggregate
      * @see Aggregate
      * @see Entity
      */
-    public ThirdPartyPaymentAggregate(PaymentId id) {
+    public PaymentAggregate(PaymentId id) {
         super(id);
     }
 

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
@@ -24,7 +24,9 @@ import com.google.protobuf.Message;
 import org.spine3.base.CommandContext;
 import org.spine3.base.EventContext;
 import org.spine3.base.Identifiers;
+import org.spine3.money.Money;
 import org.spine3.samples.lobby.common.util.aggregate.AbstractLobbyAggregate;
+import org.spine3.samples.lobby.registration.contracts.OrderTotal;
 import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.command.Assign;
 import org.spine3.server.entity.Entity;
@@ -55,6 +57,9 @@ public class ThirdPartyPaymentAggregate
 
     @Assign
     public List<Message> handle(InstantiateThirdPartyProcessorPayment command, CommandContext context) {
+        final OrderTotal total = command.getTotal();
+        final Money orderCost = total.getTotalPrice();
+
         // TODO:01-11-16:dmytro.dashenkov: Implement.
 
         final PaymentId id = PaymentId.newBuilder()

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
@@ -81,6 +81,16 @@ public class ThirdPartyPaymentAggregate
         return Collections.singletonList(resultEvent);
     }
 
+    @Assign
+    public List<Message> handle(CompleteThirdPartyProcessorPayment command, CommandContext context) {
+        return null;
+    }
+
+    @Assign
+    public List<Message> handle(CancelThirdPartyProcessorPayment command, CommandContext context) {
+        return null;
+    }
+
     /**
      * Is the aggregate initialized?
      *

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
@@ -38,7 +38,10 @@ import static org.spine3.samples.lobby.payment.ThirdPartyProcessorPayment.Paymen
 import static org.spine3.samples.lobby.payment.ThirdPartyProcessorPayment.PaymentStatus.INITIALIZED_VALUE;
 
 /**
+ * The payment aggregate that manages connection between the app and third-party payment processors.
+ *
  * @author Dmytro Dashenkov
+ * @see org.spine3.samples.lobby.payment.procman.PaymentProcessManager
  */
 public class ThirdPartyPaymentAggregate
         extends AbstractLobbyAggregate<PaymentId, ThirdPartyProcessorPayment, ThirdPartyProcessorPayment.Builder> {
@@ -64,14 +67,17 @@ public class ThirdPartyPaymentAggregate
             throw new SecondInitializationAttempt(getId());
         }
 
+        // Update aggregate state
         final OrderTotal total = command.getTotal();
         final Money orderCost = total.getTotalPrice();
         final ThirdPartyProcessorPayment.Builder newState = getState().toBuilder()
                                                                    .setPrice(orderCost);
+        markInitialized(newState);
+
+        // Construct and return events
         final Message resultEvent = PaymentInstantiated.newBuilder()
                                                        .setId(getId())
                                                        .build();
-        markInitialized(newState);
         return Collections.singletonList(resultEvent);
     }
 

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
@@ -22,7 +22,6 @@ package org.spine3.samples.lobby.payment;
 
 import com.google.protobuf.Message;
 import org.spine3.base.CommandContext;
-import org.spine3.base.EventContext;
 import org.spine3.base.Identifiers;
 import org.spine3.money.Money;
 import org.spine3.samples.lobby.common.util.aggregate.AbstractLobbyAggregate;
@@ -30,7 +29,6 @@ import org.spine3.samples.lobby.registration.contracts.OrderTotal;
 import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.command.Assign;
 import org.spine3.server.entity.Entity;
-import org.spine3.server.event.Subscribe;
 
 import java.util.Collections;
 import java.util.List;
@@ -51,7 +49,7 @@ public class ThirdPartyPaymentAggregate
      * @see Aggregate
      * @see Entity
      */
-    protected ThirdPartyPaymentAggregate(PaymentId id) {
+    public ThirdPartyPaymentAggregate(PaymentId id) {
         super(id);
     }
 
@@ -69,10 +67,5 @@ public class ThirdPartyPaymentAggregate
                                                      .setId(id)
                                                      .build();
         return Collections.singletonList(resultEvent);
-    }
-
-    @Subscribe
-    public void on(PaymentInstantiated event, EventContext context) {
-        // TODO:01-11-16:dmytro.dashenkov: Implement.
     }
 }

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
@@ -22,11 +22,13 @@ package org.spine3.samples.lobby.payment;
 
 import com.google.protobuf.Message;
 import org.spine3.base.CommandContext;
+import org.spine3.base.EventContext;
 import org.spine3.base.Identifiers;
 import org.spine3.samples.lobby.common.util.aggregate.AbstractLobbyAggregate;
 import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.command.Assign;
 import org.spine3.server.entity.Entity;
+import org.spine3.server.event.Subscribe;
 
 import java.util.Collections;
 import java.util.List;
@@ -62,5 +64,10 @@ public class ThirdPartyPaymentAggregate
                                                      .setId(id)
                                                      .build();
         return Collections.singletonList(resultEvent);
+    }
+
+    @Subscribe
+    public void on(PaymentInstantiated event, EventContext context) {
+        // TODO:01-11-16:dmytro.dashenkov: Implement.
     }
 }

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/ThirdPartyPaymentAggregate.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.samples.lobby.payment;
+
+import com.google.protobuf.Message;
+import org.spine3.base.CommandContext;
+import org.spine3.base.Identifiers;
+import org.spine3.samples.lobby.common.util.aggregate.AbstractLobbyAggregate;
+import org.spine3.server.aggregate.Aggregate;
+import org.spine3.server.command.Assign;
+import org.spine3.server.entity.Entity;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class ThirdPartyPaymentAggregate
+        extends AbstractLobbyAggregate<PaymentId, ThirdPartyProcessorPayment, ThirdPartyProcessorPayment.Builder> {
+
+    /**
+     * Creates a new aggregate instance.
+     *
+     * @param id the ID for the new aggregate
+     *
+     * @throws IllegalArgumentException if the ID is not of one of the supported types.
+     *                                  Supported types are: {@code String}, {@code Long}, {@code Integer} and {@link Message}
+     * @see Aggregate
+     * @see Entity
+     */
+    protected ThirdPartyPaymentAggregate(PaymentId id) {
+        super(id);
+    }
+
+    @Assign
+    public List<Message> handle(InstantiateThirdPartyProcessorPayment command, CommandContext context) {
+        // TODO:01-11-16:dmytro.dashenkov: Implement.
+
+        final PaymentId id = PaymentId.newBuilder()
+                                      .setValue(Identifiers.newUuid())
+                                      .build();
+        final Message resultEvent = PaymentInstantiated.newBuilder()
+                                                     .setId(id)
+                                                     .build();
+        return Collections.singletonList(resultEvent);
+    }
+}

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
@@ -33,8 +33,10 @@ import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.Timestamps;
 import org.spine3.samples.lobby.payment.InitializeThirdPartyProcessorPayment;
 import org.spine3.samples.lobby.payment.InstantiateThirdPartyProcessorPayment;
+import org.spine3.samples.lobby.payment.PaymentCanceled;
 import org.spine3.samples.lobby.payment.PaymentCompleted;
 import org.spine3.samples.lobby.payment.PaymentId;
+import org.spine3.samples.lobby.payment.PaymentRejected;
 import org.spine3.samples.lobby.payment.ThirdPartyPaymentAggregate;
 import org.spine3.samples.lobby.payment.procman.PaymentProcess.PaymentState;
 import org.spine3.samples.lobby.payment.repository.PaymentRepository;
@@ -102,7 +104,8 @@ public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerI
     }
 
     @Subscribe
-    public void on(PaymentCompleted event, EventContext context) {
+    public void on(PaymentCompleted event, EventContext context) throws SecondResolutionAttempt {
+        moveToStateResolved();
         final PaymentProcess state = getState();
 
         // Check whether the event is addressed to current instance of the procman
@@ -129,6 +132,18 @@ public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerI
                                          .build();
         boundedContext.getEventBus()
                       .post(externalEvent);
+    }
+
+    @Subscribe
+    public void on(PaymentRejected event, EventContext context) throws SecondResolutionAttempt {
+        // TODO:04-11-16:dmytro.dashenkov: Notify user.
+        moveToStateResolved();
+    }
+
+    @Subscribe
+    public void on(PaymentCanceled event, EventContext context) throws SecondResolutionAttempt {
+        // No used interaction here, since the payment was canceled by the used himself.
+        moveToStateResolved();
     }
 
     private void moveToStateResolved() throws SecondResolutionAttempt {

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
@@ -27,7 +27,6 @@ import org.spine3.protobuf.Timestamps;
 import org.spine3.samples.lobby.payment.InitializeThirdPartyProcessorPayment;
 import org.spine3.samples.lobby.payment.InstantiateThirdPartyProcessorPayment;
 import org.spine3.samples.lobby.payment.PaymentId;
-import org.spine3.samples.lobby.payment.SecondInstantiationAttempt;
 import org.spine3.samples.lobby.payment.ThirdPartyPaymentAggregate;
 import org.spine3.samples.lobby.payment.procman.PaymentProcess.PaymentState;
 import org.spine3.samples.lobby.payment.repository.PaymentRepository;

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
@@ -20,7 +20,15 @@
 
 package org.spine3.samples.lobby.payment.procman;
 
+import org.spine3.base.CommandContext;
+import org.spine3.samples.lobby.payment.InstantiateThirdPartyProcessorPayment;
+import org.spine3.samples.lobby.payment.SecondInstantiationAttempt;
+import org.spine3.samples.lobby.payment.procman.PaymentProcess.PaymentState;
+import org.spine3.server.command.Assign;
+import org.spine3.server.procman.CommandRouted;
 import org.spine3.server.procman.ProcessManager;
+
+import static org.spine3.samples.lobby.payment.procman.PaymentProcess.PaymentState.NOT_STARTED;
 
 /**
  * @author Dmytro Dashenkov
@@ -36,5 +44,24 @@ public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerI
      */
     public PaymentProcessManager(PaymentProcessManagerId id) {
         super(id);
+    }
+
+    @Assign
+    public CommandRouted handle(InstantiateThirdPartyProcessorPayment command, CommandContext context)
+            throws SecondInstantiationAttempt {
+        checkNotStarted();
+
+        final CommandRouted routed = newRouter().of(command, context)
+                                                .route();
+        return routed;
+    }
+
+    private void checkNotStarted() throws SecondInstantiationAttempt {
+        final PaymentProcess process = getState();
+        final PaymentState state = process.getState();
+
+        if (state != NOT_STARTED) {
+            throw new SecondInstantiationAttempt(process.getId());
+        }
     }
 }

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
@@ -37,7 +37,7 @@ import org.spine3.samples.lobby.payment.PaymentCanceled;
 import org.spine3.samples.lobby.payment.PaymentCompleted;
 import org.spine3.samples.lobby.payment.PaymentId;
 import org.spine3.samples.lobby.payment.PaymentRejected;
-import org.spine3.samples.lobby.payment.ThirdPartyPaymentAggregate;
+import org.spine3.samples.lobby.payment.PaymentAggregate;
 import org.spine3.samples.lobby.payment.procman.PaymentProcess.PaymentState;
 import org.spine3.samples.lobby.payment.repository.PaymentRepository;
 import org.spine3.samples.lobby.registration.contracts.OrderTotal;
@@ -81,7 +81,7 @@ public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerI
 
         // Create new Aggregate Repository
         final PaymentRepository repo = PaymentRepository.getInstance(boundedContext);
-        final ThirdPartyPaymentAggregate aggregate = repo.createNewAggregate();
+        final PaymentAggregate aggregate = repo.createNewAggregate();
 
         // Create InitializeThirdPartyProcessorPayment command from InstantiateThirdPartyProcessorPayment
         final PaymentId id = aggregate.getId();

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
@@ -54,7 +54,7 @@ import static org.spine3.samples.lobby.payment.procman.PaymentProcess.PaymentSta
  */
 public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerId, PaymentProcess> {
 
-    private final BoundedContext boundedContext;
+    private BoundedContext boundedContext;
 
     /**
      * Creates a new instance.
@@ -63,9 +63,12 @@ public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerI
      *
      * @throws IllegalArgumentException if the ID type is unsupported
      */
-    public PaymentProcessManager(PaymentProcessManagerId id, BoundedContext boundedContext) {
+    public PaymentProcessManager(PaymentProcessManagerId id) {
         super(id);
-        this.boundedContext = boundedContext;
+    }
+
+    public void setBoundedContext(BoundedContext context) {
+        this.boundedContext = context;
     }
 
     @Assign

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
@@ -136,7 +136,7 @@ public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerI
 
     @Subscribe
     public void on(PaymentRejected event, EventContext context) throws SecondResolutionAttempt {
-        // TODO:04-11-16:dmytro.dashenkov: Notify user.
+        // User should be notified by the MVC Controller.
         moveToStateResolved();
     }
 

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.samples.lobby.payment.procman;
+
+import org.spine3.server.procman.ProcessManager;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class PaymentProcessManager extends ProcessManager<PaymentProcessManagerId, PaymentProcess> {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id an ID for the new instance
+     *
+     * @throws IllegalArgumentException if the ID type is unsupported
+     */
+    public PaymentProcessManager(PaymentProcessManagerId id) {
+        super(id);
+    }
+}

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManagerRepository.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/procman/PaymentProcessManagerRepository.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.samples.lobby.payment.procman;
+
+import com.google.protobuf.Message;
+import org.spine3.base.EventContext;
+import org.spine3.server.BoundedContext;
+import org.spine3.server.entity.IdFunction;
+import org.spine3.server.procman.ProcessManagerRepository;
+import org.spine3.server.type.EventClass;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class PaymentProcessManagerRepository extends ProcessManagerRepository<
+        PaymentProcessManagerId,
+        PaymentProcessManager,
+        PaymentProcess> {
+
+
+    protected PaymentProcessManagerRepository(BoundedContext boundedContext) {
+        super(boundedContext);
+    }
+
+    @Override
+    public IdFunction<PaymentProcessManagerId, ? extends Message, EventContext> getIdFunction(@Nonnull EventClass eventClass) {
+        return new IdFunction<PaymentProcessManagerId, Message, EventContext>() {
+            @SuppressWarnings("OverlyStrongTypeCast")
+            @Override
+            public PaymentProcessManagerId getId(@Nonnull Message message, @Nonnull EventContext context) {
+                //// TODO:12-11-16:dmytro.dashenkov: Report hardly understandable behavior.
+                return ((PaymentProcess) message).getId();
+            }
+        };
+    }
+}

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/repository/PaymentRepository.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/repository/PaymentRepository.java
@@ -22,7 +22,7 @@ package org.spine3.samples.lobby.payment.repository;
 
 import org.spine3.base.Identifiers;
 import org.spine3.samples.lobby.payment.PaymentId;
-import org.spine3.samples.lobby.payment.ThirdPartyPaymentAggregate;
+import org.spine3.samples.lobby.payment.PaymentAggregate;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.aggregate.AggregateRepository;
 import org.spine3.server.storage.StorageFactory;
@@ -31,7 +31,7 @@ import org.spine3.server.storage.memory.InMemoryStorageFactory;
 /**
  * @author Dmytro Dashenkov
  */
-public class PaymentRepository extends AggregateRepository<PaymentId, ThirdPartyPaymentAggregate> {
+public class PaymentRepository extends AggregateRepository<PaymentId, PaymentAggregate> {
 
     @SuppressWarnings("StaticNonFinalField") // Singleton
     private static PaymentRepository defaultInstance = null;
@@ -59,15 +59,15 @@ public class PaymentRepository extends AggregateRepository<PaymentId, ThirdParty
     }
 
     /**
-     * Creates new instance of {@link ThirdPartyPaymentAggregate} and stores it in the storage.
+     * Creates new instance of {@link PaymentAggregate} and stores it in the storage.
      *
      * @return new instance of the aggregate.
      */
-    public ThirdPartyPaymentAggregate createNewAggregate() {
+    public PaymentAggregate createNewAggregate() {
         final PaymentId paymentId = PaymentId.newBuilder()
                                              .setValue(Identifiers.newUuid())
                                              .build();
-        final ThirdPartyPaymentAggregate aggregate = new ThirdPartyPaymentAggregate(paymentId);
+        final PaymentAggregate aggregate = new PaymentAggregate(paymentId);
         store(aggregate);
         return aggregate;
     }

--- a/payment/src/main/java/org/spine3/samples/lobby/payment/repository/PaymentRepository.java
+++ b/payment/src/main/java/org/spine3/samples/lobby/payment/repository/PaymentRepository.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.samples.lobby.payment.repository;
+
+import org.spine3.samples.lobby.payment.PaymentId;
+import org.spine3.samples.lobby.payment.ThirdPartyPaymentAggregate;
+import org.spine3.server.BoundedContext;
+import org.spine3.server.aggregate.AggregateRepository;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class PaymentRepository extends AggregateRepository<PaymentId, ThirdPartyPaymentAggregate> {
+
+    /**
+     * Creates a new repository instance.
+     *
+     * @param boundedContext the bounded context to which this repository belongs
+     */
+    public PaymentRepository(BoundedContext boundedContext) {
+        super(boundedContext);
+    }
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
@@ -30,12 +30,14 @@ import "spine/annotations.proto";
 import "spine/samples/lobby/registration/contracts/registration.proto";
 import "spine/samples/lobby/payment/payment.proto";
 
+// Command to create new ThirdPartyProcessorPayment.
 message InstantiateThirdPartyProcessorPayment {
 
     // Summary info about the order including spine.money.Money
     spine.samples.lobby.registration.contracts.OrderTotal total = 1;
 }
 
+// Command to initialize newly created Payment aggregate.
 message InitializeThirdPartyProcessorPayment {
 
     // Payment identifier
@@ -45,6 +47,7 @@ message InitializeThirdPartyProcessorPayment {
     spine.samples.lobby.registration.contracts.OrderTotal total = 2;
 }
 
+// Command stating the completion of the payment processing by the third-party processor.
 message CompleteThirdPartyProcessorPayment {
 
     // Payment identifier
@@ -54,6 +57,7 @@ message CompleteThirdPartyProcessorPayment {
     bool successful = 2;
 }
 
+// Command stating the cancellation of the payment by the user.
 message CancelThirdPartyProcessorPayment {
 
     // Payment identifier

--- a/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
@@ -1,0 +1,36 @@
+//
+// Copyright 2015, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.samples.lobby.payment;
+
+option (type_url_prefix) = "type.lobby.spine3.org";
+option java_package="org.spine3.samples.lobby.payment";
+option java_outer_classname = "CommandsProto";
+option java_multiple_files = true;
+
+import "spine/annotations.proto";
+import "spine/samples/lobby/registration/contracts/registration.proto";
+
+message InstantiateThirdPartyProcessorPayment {
+
+    // Summary info about the order including spine.money.Money
+    spine.samples.lobby.registration.contracts.OrderTotal total = 1;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
@@ -28,9 +28,19 @@ option java_multiple_files = true;
 
 import "spine/annotations.proto";
 import "spine/samples/lobby/registration/contracts/registration.proto";
+import "spine/samples/lobby/payment/payment.proto";
 
 message InstantiateThirdPartyProcessorPayment {
 
     // Summary info about the order including spine.money.Money
     spine.samples.lobby.registration.contracts.OrderTotal total = 1;
+}
+
+message InitializeThirdPartyProcessorPayment {
+
+    // Payment identifier
+    spine.samples.lobby.payment.PaymentId id = 1;
+
+    // Summary info about the order including spine.money.Money
+    spine.samples.lobby.registration.contracts.OrderTotal total = 2;
 }

--- a/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/commands.proto
@@ -44,3 +44,18 @@ message InitializeThirdPartyProcessorPayment {
     // Summary info about the order including spine.money.Money
     spine.samples.lobby.registration.contracts.OrderTotal total = 2;
 }
+
+message CompleteThirdPartyProcessorPayment {
+
+    // Payment identifier
+    spine.samples.lobby.payment.PaymentId id = 1;
+
+    // Was the payment successful?
+    bool successful = 2;
+}
+
+message CancelThirdPartyProcessorPayment {
+
+    // Payment identifier
+    spine.samples.lobby.payment.PaymentId id = 1;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/events.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/events.proto
@@ -46,3 +46,9 @@ message PaymentRejected {
     // Payment ID
     spine.samples.lobby.payment.PaymentId id = 1;
 }
+
+message PaymentCanceled {
+
+    // Payment ID
+    spine.samples.lobby.payment.PaymentId id = 1;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/events.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/events.proto
@@ -29,26 +29,30 @@ option java_multiple_files = true;
 import "spine/annotations.proto";
 import "spine/samples/lobby/payment/payment.proto";
 
+// Event which is raised when a payment aggregate is initialized.
 message PaymentInstantiated {
 
-    // Payment ID
+    // ID of the target aggregate
     spine.samples.lobby.payment.PaymentId id = 1;
 }
 
+// Event which is raised when the payment is completed successfully.
 message PaymentCompleted {
 
-    // Payment ID
+    // ID of the target aggregate
     spine.samples.lobby.payment.PaymentId id = 1;
 }
 
+// Event which is raised when the payment is rejected by the payment processor.
 message PaymentRejected {
 
-    // Payment ID
+    // ID of the target aggregate
     spine.samples.lobby.payment.PaymentId id = 1;
 }
 
+// Event which is raised when the payment is canceled by the user.
 message PaymentCanceled {
 
-    // Payment ID
+    // ID of the target aggregate
     spine.samples.lobby.payment.PaymentId id = 1;
 }

--- a/payment/src/main/proto/spine/samples/lobby/payment/events.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/events.proto
@@ -1,0 +1,47 @@
+//
+// Copyright 2015, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.samples.lobby.payment;
+
+option (type_url_prefix) = "type.lobby.spine3.org";
+option java_package="org.spine3.samples.lobby.payment";
+option java_outer_classname = "EventsProto";
+option java_multiple_files = true;
+
+import "spine/annotations.proto";
+
+message PaymentInstantiated {
+
+    // Payment ID
+    spine.samples.lobby.payment.PaymentId id = 1;
+}
+
+message PaymentCompleted {
+
+    // Payment ID
+    spine.samples.lobby.payment.PaymentId id = 1;
+}
+
+message PaymentRejected {
+
+    // Payment ID
+    spine.samples.lobby.payment.PaymentId id = 1;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/events.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/events.proto
@@ -27,6 +27,7 @@ option java_outer_classname = "EventsProto";
 option java_multiple_files = true;
 
 import "spine/annotations.proto";
+import "spine/samples/lobby/payment/payment.proto";
 
 message PaymentInstantiated {
 

--- a/payment/src/main/proto/spine/samples/lobby/payment/failures.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/failures.proto
@@ -19,16 +19,16 @@
 //
 syntax = "proto3";
 
-package spine.samples.lobby.payment.procman;
+package spine.samples.lobby.payment;
 
 option (type_url_prefix) = "type.lobby.spine3.org";
-option java_package="org.spine3.samples.lobby.payment.procman";
+option java_package="org.spine3.samples.lobby.payment";
 
 import "spine/annotations.proto";
-import "spine/samples/lobby/payment/procman/procman.proto";
+import "spine/samples/lobby/payment/payment.proto";
 
-message SecondInstantiationAttempt {
+message SecondInitializationAttempt {
 
     // ID of the existing process
-    spine.samples.lobby.payment.procman.PaymentProcessManagerId processId = 1;
+    spine.samples.lobby.payment.PaymentId processId = 1;
 }

--- a/payment/src/main/proto/spine/samples/lobby/payment/failures.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/failures.proto
@@ -32,3 +32,21 @@ message SecondInitializationAttempt {
     // ID of the existing process
     spine.samples.lobby.payment.PaymentId processId = 1;
 }
+
+message NotInitialized {
+
+    // ID of the existing process
+    spine.samples.lobby.payment.PaymentId processId = 1;
+}
+
+message AmbiguousPaymentResult {
+
+    // ID of the existing process
+    spine.samples.lobby.payment.PaymentId processId = 1;
+
+    // Current status of the payment aggregate
+    spine.samples.lobby.payment.ThirdPartyProcessorPayment.PaymentStatus current_status = 2;
+
+    // Status of the payment aggregate that was attempted to be assigned
+    spine.samples.lobby.payment.ThirdPartyProcessorPayment.PaymentStatus new_status = 3;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/failures.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/failures.proto
@@ -27,18 +27,24 @@ option java_package="org.spine3.samples.lobby.payment";
 import "spine/annotations.proto";
 import "spine/samples/lobby/payment/payment.proto";
 
+// Business failure which is thrown if the Payment aggregate had already been initialized but received another
+// initialization command.
 message SecondInitializationAttempt {
 
     // ID of the existing process
     spine.samples.lobby.payment.PaymentId processId = 1;
 }
 
+// Business failure which is thrown if the Payment aggregate had never been initialized but received a command or event
+// stating some result of a payment.
 message NotInitialized {
 
     // ID of the existing process
     spine.samples.lobby.payment.PaymentId processId = 1;
 }
 
+// Business failure which is thrown if the Payment aggregate had already received a command or an event stating
+// some result of the payment but had received one before.
 message AmbiguousPaymentResult {
 
     // ID of the existing process

--- a/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
@@ -29,6 +29,7 @@ option java_multiple_files = true;
 import "spine/annotations.proto";
 import "spine/money/money.proto";
 
+// Info about the payment for the user's order, which is handled by a third-party payment processor.
 message ThirdPartyProcessorPayment {
 
     // Identifier of the payment
@@ -50,6 +51,7 @@ message ThirdPartyProcessorPayment {
         }
 }
 
+// Unique identifier of the payment.
 message PaymentId {
 
     // String value of the ID

--- a/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
@@ -27,15 +27,27 @@ option java_outer_classname = "PaymentProto";
 option java_multiple_files = true;
 
 import "spine/annotations.proto";
-import "spine/samples/lobby/registration/contracts/registration.proto";
+import "spine/money/money.proto";
 
 message ThirdPartyProcessorPayment {
 
     // Identifier of the payment
     PaymentId id = 1;
 
-    // Total price and seat booking lines of the order
-    spine.samples.lobby.registration.contracts.OrderTotal price = 2;
+    // Total price to pay for the order
+    spine.money.Money price = 2;
+
+    // Current status of the aggregate root
+    PaymentStatus status = 3;
+
+    enum PaymentStatus {
+            NOT_STARTED = 0;
+            INITIALIZED = 1;
+            SENT_TO_PAYMENT_ENGINE = 2;
+            SUCCEED = 3;
+            FAILED = 4;
+            CANCELED = 5;
+        }
 }
 
 message PaymentId {

--- a/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
@@ -1,0 +1,45 @@
+//
+// Copyright 2015, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.samples.lobby.payment;
+
+option (type_url_prefix) = "type.lobby.spine3.org";
+option java_package="org.spine3.samples.lobby.payment";
+option java_outer_classname = "PaymentProto";
+option java_multiple_files = true;
+
+import "spine/annotations.proto";
+import "spine.samples.lobby.registration.contracts";
+
+message ThirdPartyProcessorPayment {
+
+    // Identifier of the payment
+    PaymentId id = 1;
+
+    // Total price and seat booking lines of the order
+    spine.samples.lobby.payment.OrderTotal price = 2;
+}
+
+message PaymentId {
+
+    // String value of the ID
+    string value = 1;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/payment.proto
@@ -27,7 +27,7 @@ option java_outer_classname = "PaymentProto";
 option java_multiple_files = true;
 
 import "spine/annotations.proto";
-import "spine.samples.lobby.registration.contracts";
+import "spine/samples/lobby/registration/contracts/registration.proto";
 
 message ThirdPartyProcessorPayment {
 
@@ -35,7 +35,7 @@ message ThirdPartyProcessorPayment {
     PaymentId id = 1;
 
     // Total price and seat booking lines of the order
-    spine.samples.lobby.payment.OrderTotal price = 2;
+    spine.samples.lobby.registration.contracts.OrderTotal price = 2;
 }
 
 message PaymentId {

--- a/payment/src/main/proto/spine/samples/lobby/payment/procman/failures.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/procman/failures.proto
@@ -27,12 +27,14 @@ option java_package="org.spine3.samples.lobby.payment.procman";
 import "spine/annotations.proto";
 import "spine/samples/lobby/payment/procman/procman.proto";
 
+// Business failure thrown in the procman when trying to initialize second process with the same ID.
 message SecondInstantiationAttempt {
 
     // ID of the existing process
     spine.samples.lobby.payment.procman.PaymentProcessManagerId processId = 1;
 }
 
+// // Business failure thrown in the procman when trying to move process to the resoled state if it's already in it.
 message SecondResolutionAttempt {
 
     // ID of the existing process

--- a/payment/src/main/proto/spine/samples/lobby/payment/procman/failures.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/procman/failures.proto
@@ -32,3 +32,9 @@ message SecondInstantiationAttempt {
     // ID of the existing process
     spine.samples.lobby.payment.procman.PaymentProcessManagerId processId = 1;
 }
+
+message SecondResolutionAttempt {
+
+    // ID of the existing process
+    spine.samples.lobby.payment.procman.PaymentProcessManagerId processId = 1;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/procman/failures.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/procman/failures.proto
@@ -1,0 +1,34 @@
+//
+// Copyright 2015, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.samples.lobby.payment.procman;
+
+option (type_url_prefix) = "type.lobby.spine3.org";
+option java_package="org.spine3.samples.lobby.payment";
+
+import "spine/annotations.proto";
+import "spine/samples/lobby/payment/procman/procman.proto";
+
+message SecondInstantiationAttempt {
+
+    // ID of the existing process
+    spine.samples.lobby.payment.procman.PaymentProcessManagerId processId = 1;
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
@@ -57,11 +57,8 @@ message PaymentProcess {
 
     enum PaymentState {
         NOT_STARTED = 0;
-        INITIATED = 1;
-        INITIALIZED = 2;
-        SENT_TO_PAYMENT_ENGINE = 3;
-        SUCCEED = 4;
-        FAILED = 5;
-        CANCELED = 6;
+        INITIALIZED = 1;
+        SENT_TO_PAYMENT_ENGINE = 2;
+        RESOLVED = 3;
     }
 }

--- a/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
@@ -1,0 +1,63 @@
+//
+// Copyright 2015, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.samples.lobby.payment.procman;
+
+option (type_url_prefix) = "type.lobby.spine3.org";
+option java_package="org.spine3.samples.lobby.payment.procman";
+option java_outer_classname = "PaymentProcManProto";
+option java_multiple_files = true;
+
+import "spine/annotations.proto";
+import "spine/samples/lobby/payment/payment.proto";
+import "spine/net/url.proto";
+
+// TODO:02-11-16:dmytro.dashenkov: Add docs for all proto definitions in "../".
+message PaymentProcessManagerId {
+
+    // UID value for the typed identifier
+    string value = 1;
+}
+
+message PaymentProcess {
+
+    // Process managed UID
+    PaymentProcessManagerId id = 1;
+
+    // State of the payment process
+    PaymentState state = 2;
+
+    // Payment aggregate ID
+    spine.samples.lobby.payment.PaymentId aggregateId = 3;
+
+    // Third-party payment engine host
+    spine.net.Url paymentEngine = 4;
+
+    enum PaymentState {
+        NOT_STARTED = 0;
+        INITIATED = 1;
+        INITIALIZED = 2;
+        SENT_TO_PAYMENT_ENGINE = 3;
+        SUCCEED = 4;
+        FAILED = 5;
+        CANCELED = 6;
+    }
+}

--- a/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
@@ -29,6 +29,7 @@ option java_multiple_files = true;
 import "spine/annotations.proto";
 import "spine/samples/lobby/payment/payment.proto";
 import "spine/net/url.proto";
+import "spine/samples/lobby/common/common.proto";
 
 // TODO:02-11-16:dmytro.dashenkov: Add docs for all proto definitions in "../".
 message PaymentProcessManagerId {
@@ -50,6 +51,9 @@ message PaymentProcess {
 
     // Third-party payment engine host
     spine.net.Url paymentEngine = 4;
+
+    // The ID of the order.
+    spine.samples.lobby.common.OrderId order_id = 5;
 
     enum PaymentState {
         NOT_STARTED = 0;

--- a/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
+++ b/payment/src/main/proto/spine/samples/lobby/payment/procman/procman.proto
@@ -31,13 +31,14 @@ import "spine/samples/lobby/payment/payment.proto";
 import "spine/net/url.proto";
 import "spine/samples/lobby/common/common.proto";
 
-// TODO:02-11-16:dmytro.dashenkov: Add docs for all proto definitions in "../".
+// Unique identifier for the Payment process
 message PaymentProcessManagerId {
 
     // UID value for the typed identifier
     string value = 1;
 }
 
+// Metadata of the payment process.
 message PaymentProcess {
 
     // Process managed UID

--- a/payment/src/test/java/org/spine3/samples/lobby/payment/PaymentAggregateShould.java
+++ b/payment/src/test/java/org/spine3/samples/lobby/payment/PaymentAggregateShould.java
@@ -27,6 +27,9 @@ import org.spine3.base.FailureThrowable;
 import org.spine3.base.Identifiers;
 import org.spine3.samples.lobby.payment.ThirdPartyProcessorPayment.PaymentStatus;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import static org.junit.Assert.*;
 
 /**
@@ -34,6 +37,9 @@ import static org.junit.Assert.*;
  */
 @SuppressWarnings("InstanceMethodNamingConvention")
 public class PaymentAggregateShould {
+
+    private static final String WRONG_RESULT_EVENT_TYPE_ERR_TEMPLATE = "Wrong result event type: ";
+    private static final String SECOND_RESOLUTION_HANDLED = "Should not handle second payment resolution";
 
     //
     // Initialization
@@ -62,7 +68,8 @@ public class PaymentAggregateShould {
         final PaymentAggregate aggregate = Given.aggregate(stringId);
         final InitializeThirdPartyProcessorPayment command = Given.initCommand(aggregate);
         aggregate.handle(command, CommandContext.getDefaultInstance());
-        assertEquals(aggregate.getId(), aggregate.getState().getId());
+        assertEquals(aggregate.getId(), aggregate.getState()
+                                                 .getId());
     }
 
     @Test(expected = SecondInitializationAttempt.class)
@@ -80,15 +87,92 @@ public class PaymentAggregateShould {
 
     @Test
     public void handle_successful_completion_command() throws FailureThrowable {
+        final PaymentAggregate aggregate = checkProcessorResponseCommand(PaymentCompleted.class, true);
+        assertStatus(aggregate, PaymentStatus.SUCCEED);
+    }
+
+
+    @Test
+    public void handle_reject_payment_command() throws FailureThrowable {
+        final PaymentAggregate aggregate = checkProcessorResponseCommand(PaymentRejected.class, false);
+        assertStatus(aggregate, PaymentStatus.FAILED);
+    }
+
+    @Test
+    public void handle_cancel_payment_command() throws FailureThrowable {
         final PaymentAggregate aggregate = Given.initializedAggregate();
-        final CompleteThirdPartyProcessorPayment completeCommand = Given.completeCommand(aggregate, true);
-        final Message event = aggregate.handle(completeCommand, CommandContext.getDefaultInstance());
+        final CancelThirdPartyProcessorPayment command = Given.cencelCommand(aggregate);
+        final PaymentCanceled event = aggregate.handle(command, CommandContext.getDefaultInstance());
+        assertEquals(aggregate.getId(), event.getId());
+        final PaymentStatus status = aggregate.getState()
+                                              .getStatus();
+        assertEquals(PaymentStatus.CANCELED, status);
+    }
+
+    @Test
+    public void fail_to_handle_any_command_after_payment_resolved() throws FailureThrowable {
+        final PaymentAggregate aggregate = Given.initializedAggregate(); // Failure handled
+        assertEquals(aggregate.getVersion(), 1);
+
+        final CompleteThirdPartyProcessorPayment successCommand = Given.completeCommand(aggregate, true);
+        final CompleteThirdPartyProcessorPayment rejectCommand = Given.completeCommand(aggregate, false);
+        final CancelThirdPartyProcessorPayment cancelCommand = Given.cencelCommand(aggregate);
+
+        aggregate.handle(successCommand, CommandContext.getDefaultInstance()); // Failure handled
+        assertStatus(aggregate, PaymentStatus.SUCCEED);
+        assertEquals(aggregate.getVersion(), 2);
+
+        // Try to apply reject payment command
+        try {
+            aggregate.handle(rejectCommand, CommandContext.getDefaultInstance());
+            fail(SECOND_RESOLUTION_HANDLED);
+        } catch (AmbiguousPaymentResult ignored) {
+        }
+        // Try to apply successful payment command one more time
+        try {
+            aggregate.handle(successCommand, CommandContext.getDefaultInstance());
+            fail(SECOND_RESOLUTION_HANDLED);
+        } catch (AmbiguousPaymentResult ignored) {
+        }
+        // Try to apply cancel payment command
+        try {
+            aggregate.handle(cancelCommand, CommandContext.getDefaultInstance());
+            fail(SECOND_RESOLUTION_HANDLED);
+        } catch (AmbiguousPaymentResult ignored) {
+        }
+
+        // Same status and version an before the failed applications
+        assertStatus(aggregate, PaymentStatus.SUCCEED);
+        assertEquals(aggregate.getVersion(), 2);
+    }
+
+    private static <E extends Message> PaymentAggregate checkProcessorResponseCommand(Class<E> responceEventClass,
+                                                                                      boolean wasSuccessful)
+            throws FailureThrowable {
+        final PaymentAggregate aggregate = Given.initializedAggregate();
+        final CompleteThirdPartyProcessorPayment command = Given.completeCommand(aggregate, wasSuccessful);
+        final Message event = aggregate.handle(command, CommandContext.getDefaultInstance());
         assertNotNull(event);
-        assertTrue("Wrong result event type: " + event.getClass()
-                                                            .toString(), event instanceof PaymentCompleted);
-        @SuppressWarnings("TypeMayBeWeakened")
-        final PaymentCompleted actualEvent = (PaymentCompleted) event;
-        assertEquals(aggregate.getId(), actualEvent.getId());
+        assertTrue(
+                WRONG_RESULT_EVENT_TYPE_ERR_TEMPLATE + event.getClass()
+                                                            .toString(),
+                responceEventClass.isInstance(event));
+        @SuppressWarnings("unchecked") // Checked in previous line
+        final E actualEvent = (E) event;
+        try {
+            final Method idGetter = responceEventClass.getDeclaredMethod("getId");
+            assertEquals(aggregate.getId(), idGetter.invoke(actualEvent));
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            fail(e.getMessage());
+        }
+
+        return aggregate;
+    }
+
+    private static void assertStatus(PaymentAggregate aggregate, PaymentStatus status) {
+        final PaymentStatus actualStatus = aggregate.getState()
+                                                    .getStatus();
+        assertEquals(status, actualStatus);
     }
 
     private static class Given {
@@ -121,6 +205,13 @@ public class PaymentAggregateShould {
                                                         .setId(aggregate.getId())
                                                         .setSuccessful(success)
                                                         .build();
+            return command;
+        }
+
+        private static CancelThirdPartyProcessorPayment cencelCommand(PaymentAggregate aggregate) {
+            final CancelThirdPartyProcessorPayment command = CancelThirdPartyProcessorPayment.newBuilder()
+                                                                                             .setId(aggregate.getId())
+                                                                                             .build();
             return command;
         }
     }

--- a/payment/src/test/java/org/spine3/samples/lobby/payment/PaymentAggregateShould.java
+++ b/payment/src/test/java/org/spine3/samples/lobby/payment/PaymentAggregateShould.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.samples.lobby.payment;
+
+import com.google.protobuf.Message;
+import org.junit.Test;
+import org.spine3.base.CommandContext;
+import org.spine3.base.FailureThrowable;
+import org.spine3.base.Identifiers;
+import org.spine3.samples.lobby.payment.ThirdPartyProcessorPayment.PaymentStatus;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+@SuppressWarnings("InstanceMethodNamingConvention")
+public class PaymentAggregateShould {
+
+    //
+    // Initialization
+    // --------------
+
+    @Test
+    public void initialize_with_NOT_STARTED_status_value() {
+        final PaymentAggregate aggregate = Given.aggregate("some-val");
+        final ThirdPartyProcessorPayment aggregateState = aggregate.getState();
+        assertEquals(aggregateState.getStatus(), PaymentStatus.NOT_STARTED);
+        assertFalse(aggregate.isInitialized());
+    }
+
+    @Test
+    public void handle_initialization_commands() throws SecondInitializationAttempt {
+        final PaymentAggregate aggregate = Given.aggregate(Identifiers.newUuid());
+        final InitializeThirdPartyProcessorPayment command = Given.initCommand(aggregate);
+        final PaymentInstantiated event = aggregate.handle(command, CommandContext.getDefaultInstance());
+        assertEquals(command.getId(), event.getId());
+        assertTrue(aggregate.isInitialized());
+    }
+
+    @Test(expected = SecondInitializationAttempt.class)
+    public void fail_to_initialize_twice() throws SecondInitializationAttempt {
+        final PaymentAggregate aggregate = Given.aggregate(Identifiers.newUuid());
+        final InitializeThirdPartyProcessorPayment firstCommand = Given.initCommand(aggregate);
+        final InitializeThirdPartyProcessorPayment secondCommand = Given.initCommand(aggregate);
+        aggregate.handle(firstCommand, CommandContext.getDefaultInstance());
+        aggregate.handle(secondCommand, CommandContext.getDefaultInstance());
+    }
+
+    //
+    // Payment process result handling
+    // -------------------------------
+
+    @Test
+    public void handle_successful_completion_command() throws FailureThrowable {
+        final PaymentAggregate aggregate = Given.initializedAggregate();
+        final CompleteThirdPartyProcessorPayment completeCommand = Given.completeCommand(aggregate, true);
+        final List<Message> events = aggregate.handle(completeCommand, CommandContext.getDefaultInstance());
+        assertEquals(events.size(), 1);
+        final Message actualEvent = events.get(0);
+        assertNotNull(actualEvent);
+        assertTrue("Wrong result event type: " + actualEvent.getClass()
+                                                            .toString(), actualEvent instanceof PaymentCompleted);
+        final PaymentCompleted event = (PaymentCompleted) actualEvent;
+        assertEquals(aggregate.getId(), event.getId());
+    }
+
+    private static class Given {
+        private static PaymentAggregate aggregate(String stringId) {
+            final PaymentId id = PaymentId.newBuilder()
+                                          .setValue(stringId)
+                                          .build();
+            final PaymentAggregate aggregate = new PaymentAggregate(id);
+            return aggregate;
+        }
+
+        private static PaymentAggregate initializedAggregate() throws SecondInitializationAttempt {
+            final PaymentAggregate aggregate = aggregate(Identifiers.newUuid());
+            final InitializeThirdPartyProcessorPayment command = initCommand(aggregate);
+            aggregate.handle(command, CommandContext.getDefaultInstance());
+            return aggregate;
+        }
+
+        private static InitializeThirdPartyProcessorPayment initCommand(PaymentAggregate aggregate) {
+            final InitializeThirdPartyProcessorPayment command
+                    = InitializeThirdPartyProcessorPayment.newBuilder()
+                                                          .setId(aggregate.getId())
+                                                          .build();
+            return command;
+        }
+
+        private static CompleteThirdPartyProcessorPayment completeCommand(PaymentAggregate aggregate, boolean success) {
+            final CompleteThirdPartyProcessorPayment command
+                    = CompleteThirdPartyProcessorPayment.newBuilder()
+                                                        .setId(aggregate.getId())
+                                                        .setSuccessful(success)
+                                                        .build();
+            return command;
+        }
+    }
+}

--- a/payment/src/test/java/org/spine3/samples/lobby/payment/procman/PaymentProcessmanagerShould.java
+++ b/payment/src/test/java/org/spine3/samples/lobby/payment/procman/PaymentProcessmanagerShould.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.samples.lobby.payment.procman;
+
+import com.google.protobuf.Message;
+import org.junit.Test;
+import org.spine3.base.Command;
+import org.spine3.base.CommandContext;
+import org.spine3.base.Identifiers;
+import org.spine3.money.Currency;
+import org.spine3.money.Money;
+import org.spine3.protobuf.AnyPacker;
+import org.spine3.samples.lobby.payment.InitializeThirdPartyProcessorPayment;
+import org.spine3.samples.lobby.payment.InstantiateThirdPartyProcessorPayment;
+import org.spine3.samples.lobby.registration.contracts.OrderTotal;
+import org.spine3.samples.lobby.registration.contracts.SeatOrderLine;
+import org.spine3.server.BoundedContext;
+import org.spine3.server.command.CommandBus;
+import org.spine3.server.command.CommandStore;
+import org.spine3.server.procman.CommandRouted;
+import org.spine3.server.storage.StorageFactory;
+import org.spine3.server.storage.memory.InMemoryStorageFactory;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+@SuppressWarnings("InstanceMethodNamingConvention")
+public class PaymentProcessmanagerShould {
+
+    @Test
+    public void instantiate_payment_aggregate() throws SecondInstantiationAttempt {
+        final BoundedContext boundedContext = Given.boundedContext();
+        final PaymentProcessManager procMan = Given.newProcMan(boundedContext);
+        assertEquals(0, procMan.getVersion());
+        final InstantiateThirdPartyProcessorPayment command = Given.instantiateCommand();
+
+        final CommandRouted routedCommand = procMan.handle(command, CommandContext.getDefaultInstance());
+        assertEquals(0, procMan.getVersion(), 1);
+        final Collection<Command> commands = routedCommand.getProducedList();
+        assertEquals(1, commands.size());
+
+        final Command actualRoutedCommand = commands.iterator().next();
+        final Message routedCommandMessage = AnyPacker.unpack(actualRoutedCommand.getMessage());
+        assertTrue(routedCommandMessage instanceof InitializeThirdPartyProcessorPayment);
+    }
+
+    private static class Given {
+
+        private static BoundedContext boundedContext() {
+            final StorageFactory storageFactory = InMemoryStorageFactory.getInstance();
+            final CommandStore commandStore = new CommandStore(storageFactory.createCommandStorage());
+            final CommandBus commandBus = CommandBus.newInstance(commandStore);
+            final BoundedContext bc = BoundedContext.newBuilder()
+                                                    .setName("Payment-bc")
+                                                    .setMultitenant(false)
+                                                    .setStorageFactory(storageFactory)
+                                                    .setCommandBus(commandBus)
+                                                    .build();
+            return bc;
+        }
+
+        private static PaymentProcessManager newProcMan(BoundedContext bc) {
+            final PaymentProcessManagerId id = PaymentProcessManagerId.newBuilder()
+                                                                      .setValue(Identifiers.newUuid())
+                                                                      .build();
+            final PaymentProcessManager procMan = new PaymentProcessManager(id, bc);
+            return procMan;
+        }
+
+        private static InstantiateThirdPartyProcessorPayment instantiateCommand() {
+            final Money price = Money.newBuilder()
+                                     .setAmount(1)
+                                     .setCurrency(Currency.USD)
+                                     .build();
+            final SeatOrderLine orderLine = SeatOrderLine.newBuilder()
+                                                         .setLineTotal(price)
+                                                         .setQuantity(1)
+                                                         .setUnitPrice(price)
+                                                         .build();
+            final OrderTotal total = OrderTotal.newBuilder()
+                                               .setTotalPrice(price)
+                                               .addOrderLine(orderLine)
+                                               .build();
+            final InstantiateThirdPartyProcessorPayment command
+                    = InstantiateThirdPartyProcessorPayment.newBuilder()
+                                                           .setTotal(total)
+                                                           .build();
+            return command;
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,5 @@ project(':conference-contracts').projectDir = "$rootDir/conference-contracts" as
 
 include ':conference'
 project(':conference').projectDir = "$rootDir/conference" as File
+include 'payment'
+


### PR DESCRIPTION
#### What's done
 - Created `PaymentAggregate` with most of command and event handler methods.
 - Created `PaymentProcessManager` for firing events to the aggregate.
 - Created  repositories for accessing the procman and the aggregate.

#### What's left
 - Complete functionality with redirecting the user to a third-party payment processor (with also posting corresponding events).
 - Complete coverage.

#### Disclaimer
 - **Warning:** this feature isn't complete yet.
 - **Warning:** this branch is forked from `conference-bc`, which is disapproved for merging. Some git rebasing or stashing work must be done when and if this is ready to be merged with `master`.
